### PR TITLE
Mark safe statics

### DIFF
--- a/selectize/templatetags/selectize_tags.py
+++ b/selectize/templatetags/selectize_tags.py
@@ -1,7 +1,8 @@
 from django import template
 # from django.templatetags.static import static
 # see stackoverflow :http://stackoverflow.com/questions/11721818
-from django.contrib.staticfiles.templatetags.staticfiles import static 
+from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -24,8 +25,8 @@ def selectize_tags_media(media_type='css',name=''):
 		html=str_script.format(url=static('selectize/selectize.min.js'))
 		if name=='jquery':
 			html=str_script.format(url=static('selectize/jquery.min.js'))+html
-		return html
+		return mark_safe(html)
 
 	if name:name+='.'
 	fpath='selectize/css/selectize.{name}css'.format(name=name)
-	return '<link rel="stylesheet" href="{url}">'.format(url=static(fpath))
+	return mark_safe('<link rel="stylesheet" href="{url}">'.format(url=static(fpath)))


### PR DESCRIPTION
# Changes included

* _mark the statics output as a safe string_

# Aditional information
* _I'm migrating a django project, then now I'm using django 1.8 and all works fine with django-selectize, but during the migration to django 1.9 the statics returned by the template tags are scaped, then I use mark_safe witch explicitly mark a string as safe for (HTML) output purposes_



